### PR TITLE
types: panic の型をエラーに限定する

### DIFF
--- a/src/functions/panic.ts
+++ b/src/functions/panic.ts
@@ -1,3 +1,3 @@
-export default function panic<E>(error: E): never {
+export default function panic<E extends Error>(error: E): never {
   throw error;
 }


### PR DESCRIPTION
Rust がどういう挙動かは忘れたけど確かpanic!は全部エラー扱いだった気がするから制限したほうがRustっぽくなりそう